### PR TITLE
Fix broken links to core-team meeting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ here.
 
 ## Core team meetings
 
-* [core-team/meeting-2016-01-27.md](web site translations; copyright dates; naming UFCS; specialization and lifetimes)
-* [core-team/meeting-2016-01-20.md](moderator report; jemalloc; coc)
-* [core-team/meeting-2016-01-05.md](RFC 1214; FAQ; backcompat issues)
-* [core-team/meeting-2015-12-15.md](The Rust book; crates.io design; regression worries)
+* [core-team/meeting-2016-01-27.md](core-team/meeting-2016-01-27.md)
+  (web site translations; copyright dates; naming UFCS; specialization and lifetimes)
+* [core-team/meeting-2016-01-20.md](core-team/meeting-2016-01-20.md)
+  (moderator report; jemalloc; coc)
+* [core-team/meeting-2016-01-05.md](core-team/meeting-2016-01-05.md)
+  (RFC 1214; FAQ; backcompat issues)
+* [core-team/meeting-2015-12-15.md](core-team/meeting-2015-12-15.md)
+  (The Rust book; crates.io design; regression worries)
 * [core-team/meeting-2015-11-10.md](core-team/meeting-2015-11-10.md)
   (moving rustfmt into rust-lang; wiki; liblibc/winapi breakage; pattern matching updates; multirust plans)
 * [core-team/meeting-2015-11-03.md](core-team/meeting-2015-11-03.md)


### PR DESCRIPTION
Some links to core-team meeting notes were broken because Markdown formatting interpreted the parenthetical comments as the actual URLs.